### PR TITLE
Simultaneous pdf and html, with dependencies

### DIFF
--- a/_dependencies.R
+++ b/_dependencies.R
@@ -1,0 +1,69 @@
+# Created using renv::dependencies() --------------------------------------
+library(renv)
+library(rmarkdown)
+library(pak)
+library(dplyr)
+options(renv.config.pak.enabled = TRUE)
+
+x <- renv::dependencies()
+
+# Automated Installation of Libraries -------------------------------------
+
+Packages <- x |>
+  dplyr::filter(
+    !(Package %in%
+      c(
+        "anthropic",
+        "elmer",
+        "tourrGui",
+        "spida2",
+        "spida",
+        "p3d",
+        "biplot2d3d",
+        "ggord",
+        "galahr",
+        'matlib'
+      ))
+  ) |>
+  dplyr::select(Package)
+
+Packages <- unique(Packages)$Package
+
+
+pak::pak(c(Packages, "fs", "mclust", "flextable"))
+
+
+# Manual Checking of Particular Libraries ---------------------------------
+# R-Forge shouldn't be first or else it'll install packages that you don't want.
+
+# I'm going to ignore these,  as they may require a higher version of R and other things
+# "anthropic"
+# "elmer"
+
+"spida2"
+"spida"
+"p3d"
+"biplot2d3d"
+"ggord"
+"galahr"
+
+
+# I will assume that tourrGui is no longer necessary
+# install.packages("https://cran.r-project.org/src/contrib/Archive/RGtk2/RGtk2_2.20.36.3.tar.gz", type="source")
+# pak::pak("ggobi/tourr-gui")
+# "tourrGui"
+
+# `fs` appears in `fix-pkg-cites.R`
+# `mclust` appears in `09-hotelling.qmd`
+# 
+# pak::repo_add(RForge = "http://R-Forge.R-project.org")
+pak::pak(c(
+  'gmonette/spida2',
+  'gmonette/spida',
+  "p3d",
+  'Andros-Spica/biplot2d3d',
+  'uschiLaa/galahr',
+  'fawda123/ggord', #,
+  'url::https://friendly.r-universe.dev/src/contrib/matlib_1.0.1.tar.gz'
+  # 'url::https://cran.r-project.org/src/contrib/Archive/gWidgets/gWidgets_0.0-54.2.tar.gz'
+))

--- a/_dependencies.R
+++ b/_dependencies.R
@@ -56,7 +56,7 @@ pak::pak(c(Packages, "fs", "mclust", "flextable"))
 # `fs` appears in `fix-pkg-cites.R`
 # `mclust` appears in `09-hotelling.qmd`
 # 
-# pak::repo_add(RForge = "http://R-Forge.R-project.org")
+pak::repo_add(RForge = "http://R-Forge.R-project.org")
 pak::pak(c(
   'gmonette/spida2',
   'gmonette/spida',

--- a/_quarto.yml
+++ b/_quarto.yml
@@ -164,12 +164,12 @@ format:
   #   code-block-bg: true
   # # see https://pandoc.org/MANUAL.html for all options
 
-  docx:
-    toc: true
-    toc-depth: 2
-    number-sections: true
-    highlight-style: github
-    code-link: true
+  # docx:
+  #   toc: true
+  #   toc-depth: 2
+  #   number-sections: true
+  #   highlight-style: github
+  #   code-link: true
   
   # see: https://github.com/bgreenwell/quarto-crc for quarto and CRC press
   #      https://github.com/yihui/bookdown-crc        bookdown, CRC Press
@@ -179,6 +179,8 @@ format:
     include-in-header: latex/preamble.tex
     include-before-body: latex/before-body.tex
     include-after-body: latex/after-body.tex
+    latex-output-dir: pdf
+    output-file: Vis-MLM
     keep-tex: true
     latex-tinytex: true
     # can also use pdf-engine: LatexMk / pdflatex ...


### PR DESCRIPTION
Hi @friendly,

I'm pretty sure this should solve the issue of making both a pdf and the website at once, without much user intervention.

When I go `Build -> Render Book -> All Formats`

<img width="1116" height="441" alt="image" src="https://github.com/user-attachments/assets/5efaa2ef-5486-4308-9b59-d63fdf399db6" />

Then I get the `pdf` named as `docs/Visualizing-Multivariate-Data-and-Models-in-R.pdf`. 

The `tex` is saved in the root directory `Visualizing-Multivariate-Data-and-Models-in-R.tex`, which may be helpful for debugging. 

Log files and etc are still saved under the `pdf` directory.
